### PR TITLE
Update assembledEdges in shapes.py

### DIFF
--- a/cadquery/occ_impl/shapes.py
+++ b/cadquery/occ_impl/shapes.py
@@ -809,12 +809,15 @@ class Wire(Shape, Mixin1D):
         """
             Attempts to build a wire that consists of the edges in the provided list
             :param cls:
-            :param listOfEdges: a list of Edge objects
+            :param listOfEdges: a list of Edge objects. The edges are not to be consecutive.
             :return: a wire with the edges assembled
         """
+        
         wire_builder = BRepBuilderAPI_MakeWire()
-        for edge in listOfEdges:
-            wire_builder.Add(edge.wrapped)
+        edges_list = TopTools_ListOfShape()
+        for e in listOfEdges:
+            edges_list.Append(e.wrapped) 
+        wire_builder.Add(edges_list)
 
         return cls(wire_builder.Wire())
 


### PR DESCRIPTION
```BRepBuilderAPI_MakeWire::Add(const TopTools_ListOfShape & L)``` offers the option to accept a list of shapes directly as argument:
```Adds the edges of <L> to the current wire. The edges are not to be consecutive. But they are to be all connected geometrically or topologically. If some of them are not connected the Status give DisconnectedWire but the "Maker" is Done() and you can get the partial result. (ie connected to the first edgeof the list <L>)```
Following this I modified the ```assembledEdges``` in ```shapes.py``` to be able to provide a list of unordered edges to ```BRepBuilderAPI_MakeWire```. This way, when the list of edges is generated by another function, there is not need to make them consecutive.